### PR TITLE
Autolink aritsts take II

### DIFF
--- a/api/apps/search/index.coffee
+++ b/api/apps/search/index.coffee
@@ -1,0 +1,7 @@
+express = require 'express'
+routes = require './routes'
+{ setUser, authenticated, adminOnly } = require '../users/routes'
+
+app = module.exports = express()
+
+app.get '/search', routes.index

--- a/api/apps/search/queries.coffee
+++ b/api/apps/search/queries.coffee
@@ -1,0 +1,19 @@
+module.exports =
+  matchAll: (term) ->
+    {
+      bool: {
+        must: {
+          multi_match: {
+            query: term,
+            type: 'best_fields',
+            fields: ['name.*', 'alternate_names.*'],
+            fuzziness: 2
+          }
+        }
+        should: {
+          match_phrase: {
+            name: term
+          }
+        }
+      }
+    }

--- a/api/apps/search/routes.coffee
+++ b/api/apps/search/routes.coffee
@@ -1,0 +1,29 @@
+_ = require 'underscore'
+search = require '../../lib/elasticsearch.coffee'
+
+
+# GET /api/search
+@index = (req, res, next) ->
+  search.client.search(
+      body:
+        query: {
+          bool: {
+            must: {
+              multi_match: {
+                query: req.query.term,
+                type: 'best_fields',
+                fields: ['name.*', 'alternate_names.*'],
+                fuzziness: 2
+              }
+            }
+            should: {
+              match_phrase: {
+                name: req.query.term
+              }
+            }
+          }
+        }
+      , (error, response) ->
+        return console.log("nothing matched for: #{req.query.term}") if error
+        res.send response.hits
+    )

--- a/api/apps/search/routes.coffee
+++ b/api/apps/search/routes.coffee
@@ -1,28 +1,12 @@
 _ = require 'underscore'
 search = require '../../lib/elasticsearch.coffee'
-
+queries = require './queries.coffee'
 
 # GET /api/search
 @index = (req, res, next) ->
   search.client.search(
       body:
-        query: {
-          bool: {
-            must: {
-              multi_match: {
-                query: req.query.term,
-                type: 'best_fields',
-                fields: ['name.*', 'alternate_names.*'],
-                fuzziness: 2
-              }
-            }
-            should: {
-              match_phrase: {
-                name: req.query.term
-              }
-            }
-          }
-        }
+        query: queries.matchAll(req.query.term)
       , (error, response) ->
         return console.log("nothing matched for: #{req.query.term}") if error
         res.send response.hits

--- a/api/index.coffee
+++ b/api/index.coffee
@@ -38,6 +38,7 @@ app.use require './apps/tags'
 app.use require './apps/verticals'
 app.use require './apps/authors'
 app.use require './apps/graphql'
+app.use require './apps/search'
 
 if SENTRY_PRIVATE_DSN
   app.use RavenServer.errorHandler()

--- a/client/models/article.coffee
+++ b/client/models/article.coffee
@@ -120,8 +120,12 @@ module.exports = class Article extends Backbone.Model
     _.extend super, extended
 
   replaceLink: (taggedText, link) ->
+    console.log("=====>1")
     @sections.map (section) ->
+      console.log("=====>2")
       if section.get('type') is 'text'
+        console.log("=====>3")
         text = section.get('body')
         if text.includes(taggedText)
+          console.log("=====>4 #{taggedText}, link: #{taggedText}")
           section.set('body', text.replace(taggedText, link))

--- a/client/models/article.coffee
+++ b/client/models/article.coffee
@@ -120,12 +120,8 @@ module.exports = class Article extends Backbone.Model
     _.extend super, extended
 
   replaceLink: (taggedText, link) ->
-    console.log("=====>1")
     @sections.map (section) ->
-      console.log("=====>2")
       if section.get('type') is 'text'
-        console.log("=====>3")
         text = section.get('body')
         if text.includes(taggedText)
-          console.log("=====>4 #{taggedText}, link: #{taggedText}")
           section.set('body', text.replace(taggedText, link))

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "express-force-ssl": "^0.3.0",
     "express-graphql": "^0.5.4",
     "express-ipfilter": "^0.2.3",
-    "fast-levenshtein": "^2.0.6",
     "forever": "^0.15.1",
     "glossary": "^0.1.1",
     "google-spreadsheet": "^2.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3488,7 +3488,7 @@ fast-deep-equal@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-0.1.0.tgz#5c6f4599aba6b333ee3342e2ed978672f1001f8d"
 
-fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.4:
+fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 


### PR DESCRIPTION
# Problem
With current Implementation where we call Gravity for search, we do get lot of fuzzy results, searching for `Beth Stephsen` ends up replacing that text with `Bethesda` the city, this happens because Gravity's search is optimized for artsy.net search access.

# Solution
Positron already has access to ES, now we directly hit ES with specific query (which we can still improve) and when we get the results back now we have hit score which we can use to filter results with poor hit score.
Also as part of this we now check to see if that hit result is visible on artsy and is public, otherwise we ignore it.

The thing we lost here though is now we have to create links manually as opposed to using Gravity V2 `self.link` result. Which i think its ok, we had to modify that for specific models anyways. For now i have hardcoded links to arty.net but we can cleanup this before merging to Artsy repo

As part of this I added a new `search` folder under `api` and mounted that new endpoint under `api/search`.

Let me know what you think, this is the PR to our other `autolink-artists` branch, didn't want to commit this somewhat big change to that one directly.